### PR TITLE
Bugfix: Change source for page count data

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "Chrome extension to show Google Docs' page count in the tab icon",
   "manifest_version": 2,
   "content_scripts": [
-  	{
+    {
      "matches": ["https://docs.google.com/document/*"],
      "run_at": "document_idle",
      "js": ["favico.min.js", "pageCount.js"]

--- a/pageCount.js
+++ b/pageCount.js
@@ -3,7 +3,7 @@ var favicon=new Favico({
 });
 
 function setPageCountBadge() {
-	pageCount = document.getElementsByClassName('jfk-tooltip-contentId')[0].textContent.split('of')[1].trim()
+	pageCount = document.getElementsByClassName('docs-print-block kix-page-bottom').length
 	favicon.badge(pageCount)
 }
 


### PR DESCRIPTION
Previous approach relies on HTML element that is not rendered
until the user hovers over pagecount div.
So using the total number of page divs from the DOM directly.

Request for review @fumblehool 