### PR TITLE
Bugfix: Handle lazy loading of pages

### DIFF
--- a/pageCount.js
+++ b/pageCount.js
@@ -7,4 +7,4 @@ function setPageCountBadge() {
 	favicon.badge(pageCount)
 }
 
-window.onload = setPageCountBadge
+window.onload = setInterval(setPageCountBadge, 1000)


### PR DESCRIPTION
For longer docs, pages are loaded over time so div count might change.
This also handles cases when page count is changed by editing on the
doc.